### PR TITLE
Fix bi-weekly reminder logic in GitHub Actions workflow

### DIFF
--- a/.github/workflows/bi-weekly-UX-WG-meeting-reminder.yaml
+++ b/.github/workflows/bi-weekly-UX-WG-meeting-reminder.yaml
@@ -52,6 +52,7 @@ jobs:
           fi
   remind:
     name: biweekly-ux-wg-meeting-reminder
+    needs: weekindex
     if: ${{ needs.weekindex.outputs.weekindex == 0 }}
     runs-on: 'ubuntu-latest'
     steps:


### PR DESCRIPTION
Fixes #176 

### Summary

This PR fixes the bi-weekly reminder logic in the GitHub Actions workflow.

- Ensuring the `remind` job runs only every other week.
- Adding the necessary `needs: weekindex` line to the `remind` job.