### PR TITLE
Update the new UX WG bi-weekly meeting time

### DIFF
--- a/.github/workflows/bi-weekly-UX-WG-meeting-reminder.yaml
+++ b/.github/workflows/bi-weekly-UX-WG-meeting-reminder.yaml
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Bi-weekly UX WG meeting reminder'
+name: "Bi-weekly UX WG meeting reminder"
 
 env:
   # The date of the first run of the action. It has to be set to a date that is on the same weekday as the cron.
   # 12/11 is Monday, so the cron is set to run on Monday.
   # Every second week of the bi-weekly cycle, the action is going to be skipped.
   # The cron time can be set to any time of the day.
-  FIRST_RUN_DATE: 2024-06-26
+  FIRST_RUN_DATE: 2024-09-30
 
 on:
   workflow_dispatch:
-  schedule: ## At 1PM UTC on every other Wednesday (1 day before the meeting time, which is 1 PM UTC on every other Thursday)
-    - cron: 0 13 * * 3
+  schedule: ## At 6PM UTC on every other Monday (1 day before the meeting time, which is 6 PM UTC on every other Tuesday)
+    - cron: 0 18 * * 1
 
 jobs:
   weekindex:
@@ -54,7 +54,7 @@ jobs:
     name: biweekly-ux-wg-meeting-reminder
     needs: weekindex
     if: ${{ needs.weekindex.outputs.weekindex == 0 }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - name: Post reminder to Slack
         uses: rtCamp/action-slack-notify@v2.2.1
@@ -63,6 +63,6 @@ jobs:
           SLACK_USERNAME: github-actions
           SLACK_TITLE: Bi-weekly UX WG meeting reminder
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          MSG_MINIMAL: 'true'
-          SLACK_CHANNEL: 'knative-ux'
+          MSG_MINIMAL: "true"
+          SLACK_CHANNEL: "knative-ux"
           SLACK_MESSAGE: The bi-weekly UX WG meeting will be happening tomorrow at this time (in 24 hours). You can join the [zoom meeting](https://zoom.us/j/98769530546), and add your agenda items to the [meeting notes](https://docs.google.com/document/d/1VCObP1IQFPDGzGG5KIgytQwX7RrU0tyeB7FGjkY0pPk/edit#heading=h.j4qyv6ihneq3)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- The meeting time for the bi-weekly UX WG meeting has been changed to every other Tueday, 2pm ET. Starting from 2024-09-30
